### PR TITLE
Updated CONTRIBUTING.md:Changed broken link indicating How to fork a repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to Contribute
 
 
-- Fork this repository - [How to fork a repository](https://services.github.com/on-demand/intro-to-github/create-pull-request)
+- Fork this repository - [How to fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
 - Clone the forked repository into local space
 - Choose any task on [Hackerrank](https://www.hackerrank.com/), [Codechef](https://www.codechef.com/) or any other online platform and solve it, (or choose your already solved question)
 - Paste the solution code in new file and name it in following format:


### PR DESCRIPTION
Issue reference #1278

Changes Made In Pull Request
 - Changed the "How to fork a repository" link which was previously returning a 404 error. 
